### PR TITLE
Add lazy model initialization to resolve DB connection timing issues

### DIFF
--- a/backend/src/configs/connectDB.js
+++ b/backend/src/configs/connectDB.js
@@ -1,18 +1,64 @@
+import mongoose from "mongoose";
 import dotenv from "dotenv";
 dotenv.config();
-import mongoose from "mongoose";
+
+
+// Create a connection object to store our database connections
+const connection = {
+    main: null,
+    chat: null,
+    isInitialized: false
+};
+
 
 export const connectDB = async () => {
-  try {
-    const URI = process.env.MONGO_URI;
-    if (!URI) {
-      throw new Error("MONGO_URI is not defined in .env file");
-    }
-    const res = await mongoose.connect(URI);
-    console.log(`MongoDB connected: ${res.connection.host}`);
-  } catch (error) {
-    console.log(`Error connecting to MongoDB: ${error.message}`);
+    try {
+        // If already initialized, just return the existing connection
+        if (connection.isInitialized) {
+            console.log("DB connections already initialized, reusing existing connections");
+            return connection;
+        }
 
-    process.exit(1);
-  }
-};
+        const MAIN_URI = process.env.MONOGO_MAINDB_URI;
+        const CHAT_URI = process.env.MONOGO_CHATDB_URI;
+        
+        if(!MAIN_URI){
+            throw new Error("MONOGO_MAINDB_URI is not defined in the environment variables.");
+        }
+        if(!CHAT_URI){
+            throw new Error("MONOGO_CHATDB_URI is not defined in the environment variables.");
+        }
+
+        // Create main database connection
+        connection.main = await mongoose.createConnection(MAIN_URI);
+        connection.main.on("connected", () => {
+            console.log("MongoDB Main Database connected successfully")
+        });
+
+        // Create chat database connection
+        connection.chat = await mongoose.createConnection(CHAT_URI);
+        connection.chat.on("connected", () => {
+            console.log("MongoDB Chat Database connected successfully")
+        });
+
+        // Handle errors for main connection
+        connection.main.on("error", (err) => {
+            console.log("MongoDB Main Database connection error: ", err)
+        });
+
+        // Handle errors for chat connection
+        connection.chat.on("error", (err) => {
+            console.log("MongoDB Chat Database connection error: ", err)
+        });
+
+        // Mark as initialized
+        connection.isInitialized = true;
+        
+        return connection;
+    } catch (error) {
+        console.log("Error in DB connection", error);
+        process.exit(1);
+    }
+}
+
+export default connection;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,17 +1,42 @@
 import app from "./app.js";
 import dotenv from "dotenv";
 dotenv.config();
-import {connectDB} from "./configs/connectDB.js"
-import {redisClient} from "./configs/connectRedis.js"
+import { connectDB } from "./configs/connectDB.js"
+import { redisClient } from "./configs/connectRedis.js"
+import { initializeModels } from "./utils/modelConnector.js";
 
 
 
 const PORT = process.env.PORT || 3000;
 
-app.listen(PORT, async ()=> {
-    await connectDB() //This is good practice to ensure DB connection before starting the server
-    await redisClient.on("ready",() => {
+// Initialize the database connections before starting the server
+const startServer = async () => {
+  try {
+    // Connect to MongoDB first
+    console.log("Connecting to MongoDB...");
+    await connectDB();
+    console.log("MongoDB connection successful");
+    
+    // Initialize all models after connection is established
+    initializeModels();
+    
+    // Then connect to Redis
+    console.log("Connecting to Redis...");
+    await new Promise((resolve) => {
+      redisClient.on("ready", () => {
         console.log("✅ Redis is connected successfully");
-    })
-    console.log(`Server is running on port ${PORT}`);
-})
+        resolve();
+      });
+    });
+    
+    // Start the server after connections are established
+    app.listen(PORT, () => {
+      console.log(`Server is running on port ${PORT}`);
+    });
+  } catch (error) {
+    console.error("Failed to start server:", error);
+    process.exit(1);
+  }
+};
+
+startServer();

--- a/backend/src/models/assignment.model.js
+++ b/backend/src/models/assignment.model.js
@@ -1,4 +1,6 @@
 import mongoose,{Schema} from "mongoose";
+import connection from "../configs/connectDB.js";
+import { createModel } from "../utils/modelConnector.js";
 
 
 const assignmentSchema = new Schema({
@@ -44,5 +46,5 @@ const assignmentSchema = new Schema({
     timestamps: true
 })
 
-const Assignment = mongoose.model("Assignment", assignmentSchema);
+const Assignment = createModel("Assignment", assignmentSchema, "main");
 export default Assignment;

--- a/backend/src/models/blacklisttoken.model.js
+++ b/backend/src/models/blacklisttoken.model.js
@@ -1,4 +1,6 @@
 import mongoose, { Mongoose } from "mongoose";
+import connection from "../configs/connectDB.js";
+import { createModel } from "../utils/modelConnector.js";
 
 const blacklistTokenSchema = new mongoose.Schema({
     token:{
@@ -13,5 +15,5 @@ const blacklistTokenSchema = new mongoose.Schema({
     }
 });
 
-const blacklistTokenModel = mongoose.model('BlacklistToken',blacklistTokenSchema)
+const blacklistTokenModel = createModel('BlacklistToken', blacklistTokenSchema, "main");
 export default blacklistTokenModel;

--- a/backend/src/models/branch.model.js
+++ b/backend/src/models/branch.model.js
@@ -1,4 +1,6 @@
 import mongoose from "mongoose";
+import connection from "../configs/connectDB.js";
+import { createModel } from "../utils/modelConnector.js";
 
 const branchSchema = new mongoose.Schema({
     name: {
@@ -17,5 +19,5 @@ const branchSchema = new mongoose.Schema({
 }, {
     timestamps: true,
 });
-const Branch = mongoose.model("Branch", branchSchema);
+const Branch = createModel("Branch", branchSchema, "main");
 export default Branch;

--- a/backend/src/models/chapter.model.js
+++ b/backend/src/models/chapter.model.js
@@ -1,4 +1,6 @@
 import mongoose,{Schema} from "mongoose";
+import connection from "../configs/connectDB.js";
+import { createModel } from "../utils/modelConnector.js";
 
 
 const chapterSchema = new Schema({
@@ -34,5 +36,5 @@ const chapterSchema = new Schema({
 chapterSchema.index({ subject: 1, chapter_no: 1 }, { unique: true });
 chapterSchema.index({ subject: 1, order: 1 });
 
-const Chapter = mongoose.model("Chapter", chapterSchema);
+const Chapter = createModel("Chapter", chapterSchema, "main");
 export default Chapter;

--- a/backend/src/models/degree.model.js
+++ b/backend/src/models/degree.model.js
@@ -1,4 +1,6 @@
 import mongoose from "mongoose";
+import connection from "../configs/connectDB.js";
+import { createModel } from "../utils/modelConnector.js";
 
 const degreeSchema = new mongoose.Schema({
     name: {
@@ -18,6 +20,5 @@ const degreeSchema = new mongoose.Schema({
     timestamps: true,
 })
 
-const Degree = mongoose.model("Degree", degreeSchema);
-
+const Degree = createModel("Degree", degreeSchema, "main");
 export default Degree;

--- a/backend/src/models/department.model.js
+++ b/backend/src/models/department.model.js
@@ -1,4 +1,6 @@
 import mongoose from 'mongoose';
+import connection from '../configs/connectDB.js';
+import { createModel } from "../utils/modelConnector.js";
 
 
 const departmentSchema = new mongoose.Schema({
@@ -19,5 +21,5 @@ const departmentSchema = new mongoose.Schema({
     timestamps: true,
 })
 
-const Department = mongoose.model("Department", departmentSchema);
+const Department = createModel("Department", departmentSchema, "main");
 export default Department;

--- a/backend/src/models/notes.model.js
+++ b/backend/src/models/notes.model.js
@@ -1,4 +1,6 @@
 import mongoose, { Schema } from "mongoose";
+import connection from "../configs/connectDB.js";
+import { createModel } from "../utils/modelConnector.js";
 
 
 const notesSchema = new Schema(
@@ -70,5 +72,5 @@ const notesSchema = new Schema(
 notesSchema.index({ subject: 1, chapter: 1 });
 notesSchema.index({ title: "text", description: "text" });
 
-const Notes = mongoose.model("Notes", notesSchema);
+const Notes = createModel("Notes", notesSchema, "main");
 export default Notes;

--- a/backend/src/models/notification.model.js
+++ b/backend/src/models/notification.model.js
@@ -1,4 +1,6 @@
 import mongoose, { Schema } from "mongoose";
+import connection from "../configs/connectDB.js";
+import { createModel } from "../utils/modelConnector.js";
 
 const notificationSchema = new Schema({
   title: {
@@ -60,5 +62,5 @@ const notificationSchema = new Schema({
     timestamps: true,
 });
 
-const Notification = mongoose.model("Notification", notificationSchema);
+const Notification = createModel("Notification", notificationSchema, "main");
 export default Notification;

--- a/backend/src/models/section.model.js
+++ b/backend/src/models/section.model.js
@@ -1,4 +1,6 @@
 import mongoose,{Schema} from "mongoose";
+import connection from "../configs/connectDB.js";
+import { createModel } from "../utils/modelConnector.js";
 
 const sectionSchema = new Schema({
   section_name: {
@@ -58,12 +60,11 @@ const sectionSchema = new Schema({
 
 
 
-
 sectionSchema.methods.isTeacherInSection = function(teacherId) {
   return this.faculty.some(f => 
     f.teacher && f.teacher.toString() === teacherId.toString()
   );
 };
 
-const Section = mongoose.model("Section", sectionSchema);
+const Section = createModel("Section", sectionSchema, "main");
 export default Section;

--- a/backend/src/models/student.model.js
+++ b/backend/src/models/student.model.js
@@ -1,6 +1,8 @@
 import mongoose,{Schema} from "mongoose";
 import jwt from "jsonwebtoken";
 import bcrypt from "bcryptjs";
+import connection from "../configs/connectDB.js";
+import { createModel } from "../utils/modelConnector.js";
 
 
 const studentSchema = new Schema({
@@ -138,6 +140,6 @@ studentSchema.methods.generateRefreshToken = function () {
 }
 
 
-const Student = mongoose.model("Student", studentSchema);
+const Student = createModel("Student", studentSchema, "main");
 
 export default Student;

--- a/backend/src/models/subject.model.js
+++ b/backend/src/models/subject.model.js
@@ -1,4 +1,6 @@
 import mongoose from "mongoose";
+import connection from "../configs/connectDB.js";
+import { createModel } from "../utils/modelConnector.js";
 
 const subjectSchema = new mongoose.Schema({
   subject_code: {
@@ -40,5 +42,11 @@ const subjectSchema = new mongoose.Schema({
   timestamps: true,
 });
 
-const Subject = mongoose.model("Subject", subjectSchema);
+// Register the model with the connection
+if (connection.main) {
+  connection.main.model("Subject", subjectSchema);
+}
+
+// Get the model using the proxy approach for safe access
+const Subject = createModel("Subject", subjectSchema, "main");
 export default Subject;

--- a/backend/src/models/teacher.model.js
+++ b/backend/src/models/teacher.model.js
@@ -1,6 +1,8 @@
 import mongoose,{Schema} from "mongoose";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
+import connection from "../configs/connectDB.js";
+import { createModel } from "../utils/modelConnector.js";
 
 const teacherSchema = new Schema({
     full_name:{
@@ -100,7 +102,7 @@ teacherSchema.methods.generateRefreshToken = function() {
     return jwt.sign({ id: this._id, email: this.email }, process.env.REFRESH_TOKEN_SECRET, { expiresIn: '30d' });
 }
 
-const Teacher = mongoose.model("Teacher", teacherSchema);
+const Teacher = createModel("Teacher", teacherSchema, "main");
 export default Teacher;
 
 

--- a/backend/src/utils/modelConnector.js
+++ b/backend/src/utils/modelConnector.js
@@ -1,0 +1,143 @@
+import connection from "../configs/connectDB.js";
+
+// Store for schema registrations
+const schemaRegistry = new Map();
+const modelCache = new Map();
+
+/**
+ * Register a schema that will be used to create models later
+ * @param {string} modelName - The name of the model
+ * @param {object} schema - The mongoose schema
+ * @param {string} connectionType - Which connection to use ('main' or 'chat')
+ */
+export const registerSchema = (modelName, schema, connectionType = 'main') => {
+  const key = `${modelName}_${connectionType}`;
+  schemaRegistry.set(key, { modelName, schema, connectionType });
+};
+
+
+//Initialize all registered models after connection is established
+
+export const initializeModels = () => {
+  console.log('Initializing models...');
+  for (const [key, { modelName, schema, connectionType }] of schemaRegistry) {
+    if (connection[connectionType]) {
+      try {
+        const model = connection[connectionType].model(modelName, schema);
+        modelCache.set(key, model);
+        console.log(`Model ${modelName} initialized successfully`);
+      } catch (error) {
+        if (error.message.includes('Cannot overwrite')) {
+          // Model already exists
+          const model = connection[connectionType].model(modelName);
+          modelCache.set(key, model);
+          console.log(`Model ${modelName} already exists, using existing model`);
+        } else {
+          console.error(`Error initializing model ${modelName}:`, error.message);
+        }
+      }
+    }
+  }
+};
+
+/**
+ * Get a model by name
+ * @param {string} modelName - The name of the model
+ * @param {string} connectionType - Which connection to use ('main' or 'chat')
+ * @returns {object} The mongoose model
+ */
+export const getModel = (modelName, connectionType = 'main') => {
+  const key = `${modelName}_${connectionType}`;
+  const model = modelCache.get(key);
+  
+  if (!model) {
+    throw new Error(`Model ${modelName} not found. Make sure models are initialized after database connection.`);
+  }
+  
+  return model;
+};
+
+/**
+ * Creates a model placeholder that will be initialized later
+ * @param {string} modelName - The name of the model
+ * @param {object} schema - The mongoose schema
+ * @param {string} connectionType - Which connection to use ('main' or 'chat')
+ * @returns {Proxy} A proxy that acts like a Mongoose model
+ */
+export const createModel = (modelName, schema, connectionType = 'main') => {
+  // Register schema for later initialization
+  registerSchema(modelName, schema, connectionType);
+
+  // This will hold the actual model once initialized
+  let modelInstance = null;
+
+  // Helper to get the actual model (throws if not initialized)
+  const getActualModel = () => {
+    if (!modelInstance) {
+      const key = `${modelName}_${connectionType}`;
+      modelInstance = modelCache.get(key);
+      if (!modelInstance) {
+        throw new Error(
+          `Model ${modelName} not found. Ensure initializeModels() is called after DB connection.`
+        );
+      }
+    }
+    return modelInstance;
+  };
+
+  // Return a Proxy that intercepts all property/method access
+  return new Proxy(
+    function () {
+      // Allow the proxy to be used as a constructor: new Model()
+      const model = getActualModel();
+      return new (Function.prototype.bind.apply(model, arguments))();
+    },
+    {
+      // Handle property access (e.g., Model.schema, Model.modelName)
+      get(target, prop) {
+        const model = getActualModel();
+
+        const value = model[prop];
+        if (typeof value === 'function') {
+          // Bind functions to the model context
+          return value.bind(model);
+        }
+        return value;
+      },
+
+      // Allow setting properties (rarely used, but just in case)
+      set(target, prop, value) {
+        const model = getActualModel();
+        model[prop] = value;
+        return true;
+      },
+
+      // Support for instanceof checks (optional)
+      has(target, prop) {
+        const model = getActualModel();
+        return prop in model;
+      },
+
+      // Make the proxy appear like the real model in console.log
+      ownKeys() {
+        const model = getActualModel();
+        return [...new Set([...Object.keys(model), ...Object.getOwnPropertyNames(model.constructor.prototype)])];
+      },
+
+      getOwnPropertyDescriptor(target, prop) {
+        const model = getActualModel();
+        const desc = Object.getOwnPropertyDescriptor(model, prop);
+        if (desc) return desc;
+        // Also check prototype chain
+        const protoDesc = Object.getOwnPropertyDescriptor(model.constructor.prototype, prop);
+        return protoDesc;
+      },
+
+      // Handle constructor calls (new Model())
+      construct(target, args) {
+        const model = getActualModel();
+        return new model(...args);
+      }
+    }
+  );
+};


### PR DESCRIPTION
Implement lazy model initialization to resolve database connection timing issues

- Add modelConnector utility with proxy-based lazy loading for Mongoose models
- Replace direct model creation with createModel() wrapper that defers initialization
- Update all model files to use createModel() instead of direct mongoose.model()
- Implement schema registry and model cache for proper initialization order
- Add initializeModels() function to create models after DB connection is established
- Update index.js to call initializeModels() after connectDB() succeeds
- Fix "Cannot read properties of undefined/null (reading 'model')" errors
- Fix "Schema hasn't been registered for model" errors
- Ensure all Mongoose model methods are properly proxied and accessible
- Support both static methods (findOne, create, etc.) and constructor usage (new Model())

This resolves the race condition where models were being created before the database
connection was established, causing the application to crash on startup.